### PR TITLE
test.py: improve test script

### DIFF
--- a/test.py
+++ b/test.py
@@ -26,14 +26,13 @@ def media_type_from_source(source_type):
 
 
 def get_query_for_source_type(source_type):
-    return """SELECT DISTINCT ?test_uri ?test_id WHERE { 
-        ?test_uri rdf:type <http://www.w3.org/ns/earl#TestCase> . 
+    return """SELECT DISTINCT ?test_uri ?test_id WHERE {
+        ?test_uri rdf:type <http://www.w3.org/ns/earl#TestCase> .
         ?test_uri <http://purl.org/dc/terms/identifier> ?test_id .
         ?test_uri <http://purl.org/dc/terms/hasPart> ?part .
         ?part rdf:type <http://www.w3.org/ns/dcat#Dataset> .
         ?part <http://www.w3.org/ns/dcat#distribution> ?dist .
         ?dist <http://www.w3.org/ns/dcat#mediaType> """ + media_type_from_source(source_type) + """
-        
     } ORDER BY ?test_uri"""
 
 
@@ -68,8 +67,7 @@ def run_test(t_identifier, expected_output, source_type):
     if expected_output:
         expected_output_graph.parse("./output.nq", format="nquads")
 
-    os.system(config["properties"][
-                  "engine_command"] + " > test-cases/" + t_identifier + "/engine_output-" + source_type + ".log")
+    os.system(config["properties"]["engine_command"] + " > test-cases/" + t_identifier + "/engine_output-" + source_type + ".log")
 
     # if there is output file
     if os.path.isfile(config["properties"]["output_results"]):

--- a/test.py
+++ b/test.py
@@ -168,11 +168,15 @@ def write_results():
 
 
 if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Configuration file is missing: python3 test.py <config file>")
+        sys.exit(1)
+
     config_file = str(sys.argv[1])
     if not os.path.isfile(config_file):
         print("The configuration file " + config_file + " does not exist.")
         print("Aborting...")
-        sys.exit(1)
+        sys.exit(2)
 
     config = ConfigParser(interpolation=ExtendedInterpolation())
     config.read(config_file)

--- a/test.py
+++ b/test.py
@@ -1,5 +1,5 @@
 from configparser import ConfigParser, ExtendedInterpolation
-from rdflib import Graph, RDF, Namespace, compare, Literal, URIRef
+from rdflib import Graph, ConjunctiveGraph, RDF, Namespace, compare, Literal, URIRef
 from rdflib.plugins.sparql import prepareQuery
 from rdflib_hdt import HDTStore, optimize_sparql
 import mysql.connector
@@ -59,7 +59,7 @@ def test_from_source_type(source_type):
 
 
 def run_test(t_identifier, expected_output, source_type):
-    expected_output_graph = Graph()
+    expected_output_graph = ConjunctiveGraph()
 
     if os.path.isfile(config["properties"]["output_results"]):
         os.system("rm " + config["properties"]["output_results"])
@@ -75,7 +75,7 @@ def run_test(t_identifier, expected_output, source_type):
             "output_results"] + " test-cases/" + t_identifier + "/engine_output-" + source_type + ".nq")
         # and expected output is true
         if expected_output:
-            output_graph = Graph()
+            output_graph = ConjunctiveGraph()
             iso_expected = compare.to_isomorphic(expected_output_graph)
             # trying to parse the output (e.g., not valid RDF)
             try:

--- a/test.py
+++ b/test.py
@@ -71,8 +71,8 @@ def run_test(t_identifier, expected_output, source_type):
 
     # if there is output file
     if os.path.isfile(config["properties"]["output_results"]):
-        os.system("cp " + config["properties"][
-            "output_results"] + " test-cases/" + t_identifier + "/engine_output-" + source_type + ".nq")
+        extension = config["properties"]["output_results"].split(".")[-1]
+        os.system("cp " + config["properties"]["output_results"] + "test-cases/" + t_identifier + "/engine_output-" + source_type + "." + extension)
         # and expected output is true
         if expected_output:
             output_graph = ConjunctiveGraph()

--- a/test.py
+++ b/test.py
@@ -87,18 +87,22 @@ def run_test(t_identifier, expected_output, source_type):
                     result = passed
                 # and graphs are distinct
                 else:
+                    print("Output RDF does not match with the expected RDF")
                     result = failed
             # output is not valid RDF
             except:
+                print("Output RDF is invalid")
                 result = failed
 
         # and expected output is false
         else:
+            print("Output RDF found but none was expected")
             result = failed
     # if there is not output file
     else:
         # and expected output is true
         if expected_output:
+            print("No RDF output found while output was expected")
             result = failed
         # expected output is false
         else:


### PR DESCRIPTION
Similar to https://github.com/kg-construct/r2rml-test-cases-support/pull/2:
- Test if a configuration file was supplied as an argument since the script expects that at least one argument is supplied.
- Print the reason why a test-case failed, makes it easier to debug.
- Allow any output extension besides `.nq`, `.nq` can trigger the NQuad parser in RDFLib.